### PR TITLE
Apply libtool patch only when the project uses libtool

### DIFF
--- a/coin.m4
+++ b/coin.m4
@@ -101,15 +101,33 @@ AC_DEFUN([AC_COIN_ENABLE_MSVC],
     [enable_msvc=no])
 ])
 
+
+###########################################################################
+#                          COIN_ENABLE_DEBUG                              # 
+###########################################################################
+
+# This macro is invoked by any PROG_compiler macro to establish the
+# --enable-debug option.
+
+AC_DEFUN([AC_COIN_ENABLE_DEBUG],
+[
+  AC_ARG_ENABLE([debug],
+    [AC_HELP_STRING([--enable-debug],
+       [Build with debugging symbols.])],
+    [enable_debug=$enableval],
+    [enable_debug=no])
+])
+
 ###########################################################################
 #                        COIN_COMPFLAGS_DEFAULTS                          #
 ###########################################################################
 
 AC_DEFUN([AC_COIN_COMPFLAGS_DEFAULTS],
 [
-# We want --enable-msvc setup and checked
+# We want --enable-msvc setup and checked. Also --enable-debug
 
   AC_REQUIRE([AC_COIN_ENABLE_MSVC])
+  AC_REQUIRE([AC_COIN_ENABLE_DEBUG])
 
 # This macro should run before the compiler checks (doesn't seem to be
 # sufficient for CFLAGS)
@@ -133,8 +151,13 @@ AC_DEFUN([AC_COIN_COMPFLAGS_DEFAULTS],
   else
     : ${FFLAGS:=""}
     : ${FCFLAGS:=""}
-    : ${CFLAGS:="-DNDEBUG"}
-    : ${CXXFLAGS:="-DNDEBUG"}
+    if test "$enable_debug" = yes ; then
+      : ${CFLAGS:="-g"}
+      : ${CXXFLAGS:="-g"}
+    else
+      : ${CFLAGS:="-DNDEBUG"}
+      : ${CXXFLAGS:="-DNDEBUG"}
+    fi
   fi
 ])
 

--- a/coin.m4
+++ b/coin.m4
@@ -660,7 +660,8 @@ AC_DEFUN([AC_COIN_CHK_MOD_EXISTS],
 # the various OsiXxxLib solvers, which depend on OsiLib. We can't consult
 # osi.pc (it's not installed yet) but the relevant variables are ready at
 # hand. The name of prim is often different from the name of the .pc file
-# ($3), hence the separate parameter.
+# ($3), hence the separate parameter. If $3 is not given, it defaults to
+# tolower($1).
 
 # This macro should be called after FINALIZE_FLAGS is invoked for the
 # client packages, for two reasons: First, COIN packages tend to use
@@ -683,7 +684,7 @@ AC_DEFUN([AC_COIN_CHK_HERE],
 # Add the .pc file and augment LFLAGS and CFLAGS.
 
     m4_foreach_w([myvar],[$2],
-      [m4_toupper(myvar)_PCFILES="$m4_toupper(myvar)_PCFILES $3"
+      [m4_toupper(myvar)_PCFILES="$m4_toupper(myvar)_PCFILES m4_default($3,m4_tolower($1))"
        m4_toupper(myvar)_LFLAGS="$m4_toupper(myvar)_LFLAGS $m4_toupper($1)_LFLAGS"
        m4_toupper(myvar)_CFLAGS="$m4_toupper(myvar)_CFLAGS $m4_toupper($1)_CFLAGS"
 

--- a/run_autotools
+++ b/run_autotools
@@ -472,7 +472,6 @@ if [[ $dryRun -eq 1 ]] ; then
   exit
 fi
 
-# m4Files="$AUTOTOOLS_DIR/share/aclocal/libtool.m4"
 buildtoolsLinks=
 
 for dir in ${dirs[@]} ; do
@@ -557,8 +556,14 @@ for dir in ${dirs[@]} ; do
     fi
     echo "  running aclocal in $dir"
     aclocal $m4Dirs
-    echo "  apply libtool.m4 patch to support ICL"
-    patch -p1 < BuildTools/libtool-icl.patch
+
+# Not all projects make use of libtool, so check before we try to apply the
+# libtool patch.
+
+    if grep -q -F '[_LT_COPYING]' aclocal.m4 ; then
+      echo "  apply libtool.m4 patch to support ICL"
+      patch -p1 < BuildTools/libtool-icl.patch
+    fi
     if grep AC_CONFIG_HEADER configure.ac >/dev/null 2>&1; then
       echo "  running autoheader in $dir"
       autoheader || exit 1

--- a/run_autotools
+++ b/run_autotools
@@ -60,6 +60,16 @@
 # (trunk) versions first, older (stable) versions next.
 
 case "${COIN_ENV:-git}" in
+  "mixed" )
+    repoDir='.git .svn'
+    ver_autoconf='2.69'
+    ver_automake='1.16.1'
+    ver_libtool='2.4.6'
+    ltfile=$AUTOTOOLS_DIR/share/libtool/build-aux/ltmain.sh
+    autotoolsFiles="config.guess config.sub depcomp install-sh"
+    autotoolsFiles="$autotoolsFiles ltmain.sh missing compile"
+    autotoolsFiles="$autotoolsFiles get.dependencies.sh"
+    ;;
   "git" )
     repoDir='.git'
     ver_autoconf='2.69'
@@ -189,22 +199,30 @@ checkAutotoolVersion () {
 
 # Subroutine to decide if a directory is a project. The test is presence
 # of a $repoDir (.git or .svn are the known types). There's no protection
-# against specifying an interior directory.
+# against specifying an interior directory. The loop allows for mixed git and
+# svn project directories.
 
 isAProject () {
-  if [[ -d $1/${repoDir} ]] ; then
-    return 0
-  else
-    return 1
-  fi
+  for lcldir in $repoDir ; do
+    if [[ -d $1/${lcldir} ]] ; then
+      return 0
+    fi
+  done
+  return 1
 }
 
 # Subroutine to find the project directories under a given directory. The test
 # is presence of a $repoDir directory.
 
 findProjects () {
-  local dirs=$( find $1 -type d -name ${repoDir} -print -prune )
-  echo $dirs | sed -e "s,/${repoDir},,"g
+  local dirs
+  local tmp
+  for dir in $repoDir ; do
+    tmp=$( find $1 -type d -name ${dir} -print -prune )
+    tmp=`echo $tmp | sed -e "s,/${dir},,g"`
+    dirs="$dirs $tmp"
+  done
+  echo $dirs
 }
 
 

--- a/run_autotools
+++ b/run_autotools
@@ -59,10 +59,21 @@
 # The required autotools versions, along with a few other differences. Current
 # (trunk) versions first, older (stable) versions next.
 
-case "${COIN_ENV:-trunk}" in
-  "trunk" )
+case "${COIN_ENV:-git}" in
+  "git" )
+    repoDir='.git'
     ver_autoconf='2.69'
-    ver_automake='1.15.1'
+    ver_automake='1.16.1'
+    ver_libtool='2.4.6'
+    ltfile=$AUTOTOOLS_DIR/share/libtool/build-aux/ltmain.sh
+    autotoolsFiles="config.guess config.sub depcomp install-sh"
+    autotoolsFiles="$autotoolsFiles ltmain.sh missing compile"
+    autotoolsFiles="$autotoolsFiles get.dependencies.sh"
+    ;;
+  "trunk" )
+    repoDir='.svn'
+    ver_autoconf='2.69'
+    ver_automake='1.16.1'
     ver_libtool='2.4.6'
     ltfile=$AUTOTOOLS_DIR/share/libtool/build-aux/ltmain.sh
     autotoolsFiles="config.guess config.sub depcomp install-sh"
@@ -70,6 +81,7 @@ case "${COIN_ENV:-trunk}" in
     autotoolsFiles="$autotoolsFiles get.dependencies.sh"
     ;;
   "stable" )
+    repoDir='.svn'
     ver_autoconf='2.59'
     ver_automake='1.9.6'
     ver_libtool='1.5.22'
@@ -98,11 +110,17 @@ cleanupOnErrorExit ()
 
 printHelp () {
   cat <<EOF
-usage: run_autotools [-h] [-nr] [ directory directory ... ]
+usage: run_autotools [-h] [-[n]r] [-ni] [ directory directory ... ]
 
   -h  | --help           print help message and exit
   -r  | --recursion      do recursive search for configure.ac files
-  -ni | --dependent      do not install scripts necessary for an independent unit
+  -nr | --no-recursion   do not do recursive search for configure.ac files
+  -ni | --dependent      do not install scripts necessary for an independent
+  			 unit
+  -d  | --dryrun         exit immediately after determining the list of
+                         directories to be processed
+
+  Default is no recursion, install scripts for an independent unit.
 
   If no directories and -r are specified, the tree rooted at the current
   directory is searched recursively for directories with configure.ac
@@ -110,13 +128,19 @@ usage: run_autotools [-h] [-nr] [ directory directory ... ]
   is run in those directories. Directories listed in COIN_SKIP_PROJECTS
   are skipped.  If directories are specified on the command line, the
   search for configure.ac files is restricted to the specified directories.
+  In each directory where a configure.ac file is found, this script will
+  refresh a set of autotools scripts (listed below) necessary for a unit that
+  will be installed independently.
 
-  The --dependent option will suppress installation of install-sh and other
-  scripts necessary for a unit that is installed independently. This will
-  be suppressed in *all* directories processed. Most often what is desired is
-  to install these scripts in the top-level directory of a unit, so not using -ni
-  disables -r. It's a good idea to explicitly specify the directories you want
-  to process.
+  The -ni (--dependent) option will suppress refresh of the autotools scripts
+  (but will not delete existing scripts). This will be suppressed in *all*
+  directories processed.
+
+  The most common scenario for run_autotools is to process a project with a
+  configure.ac file in the top-level directory of the project and no nested
+  configure.ac files. Hence the default of no recursion and install autotools
+  scripts.  The -r option is useful if you have multiple COIN projects in
+  sibling directories and want to do a batch run of autotools on all of them.
 
   The environment variable AUTOTOOLS_DIR can be used to point to an alternate
   installation of the autotools (current location $AUTOTOOLS_DIR)
@@ -125,6 +149,8 @@ usage: run_autotools [-h] [-nr] [ directory directory ... ]
     autoconf: $ver_autoconf
     automake: $ver_automake
     libtool:  $ver_libtool
+
+  Autotools scripts: ${autotoolsFiles}
 EOF
 }
 
@@ -162,11 +188,11 @@ checkAutotoolVersion () {
 # that I'll want to expand the test when git comes into the picture.
 
 # Subroutine to decide if a directory is a project. The test is presence
-# of a .svn directory. There's no protection against specifying an interior
-# directory.
+# of a $repoDir (.git or .svn are the known types). There's no protection
+# against specifying an interior directory.
 
 isAProject () {
-  if [[ -d $1/.svn ]] ; then
+  if [[ -d $1/${repoDir} ]] ; then
     return 0
   else
     return 1
@@ -174,11 +200,11 @@ isAProject () {
 }
 
 # Subroutine to find the project directories under a given directory. The test
-# is presence of a .svn directory.
+# is presence of a $repoDir directory.
 
 findProjects () {
-  local dirs=$( find $1 -type d -name .svn -print -prune )
-  echo $dirs | sed -e 's,/.svn,,'g
+  local dirs=$( find $1 -type d -name ${repoDir} -print -prune )
+  echo $dirs | sed -e "s,/${repoDir},,"g
 }
 
 
@@ -270,6 +296,7 @@ fi
 doRecurse=0
 suppressScripts=0
 userSpecifiedDirs=0
+dryRun=0
 
 # Process the parameters. A parameter without an opening `-' is assumed to be
 # a spec for a directory to be processed. We really shouldn't see -h here, but
@@ -289,6 +316,9 @@ while [[ $# -gt 0 ]] ; do
       ;;
     -ni | --dependent )
       suppressScripts=1
+      ;;
+    -d | --dryrun )
+      dryRun=1
       ;;
     -* ) echo "$0: unrecognised command line switch '"$1"'."
       printHelp=1
@@ -424,6 +454,10 @@ trap 'exit_status=$?
 # And now the main event. Process each directory.
 
 echo "Running autotools in ${dirs[*]}"
+
+if [[ $dryRun -eq 1 ]] ; then
+  exit
+fi
 
 # m4Files="$AUTOTOOLS_DIR/share/aclocal/libtool.m4"
 buildtoolsLinks=

--- a/run_autotools
+++ b/run_autotools
@@ -68,7 +68,7 @@ case "${COIN_ENV:-git}" in
     ltfile=$AUTOTOOLS_DIR/share/libtool/build-aux/ltmain.sh
     autotoolsFiles="config.guess config.sub depcomp install-sh"
     autotoolsFiles="$autotoolsFiles ltmain.sh missing compile"
-    autotoolsFiles="$autotoolsFiles get.dependencies.sh"
+    autotoolsFiles="$autotoolsFiles"
     ;;
   "git" )
     repoDir='.git'
@@ -78,7 +78,7 @@ case "${COIN_ENV:-git}" in
     ltfile=$AUTOTOOLS_DIR/share/libtool/build-aux/ltmain.sh
     autotoolsFiles="config.guess config.sub depcomp install-sh"
     autotoolsFiles="$autotoolsFiles ltmain.sh missing compile"
-    autotoolsFiles="$autotoolsFiles get.dependencies.sh"
+    autotoolsFiles="$autotoolsFiles"
     ;;
   "trunk" )
     repoDir='.svn'
@@ -88,7 +88,7 @@ case "${COIN_ENV:-git}" in
     ltfile=$AUTOTOOLS_DIR/share/libtool/build-aux/ltmain.sh
     autotoolsFiles="config.guess config.sub depcomp install-sh"
     autotoolsFiles="$autotoolsFiles ltmain.sh missing compile"
-    autotoolsFiles="$autotoolsFiles get.dependencies.sh"
+    autotoolsFiles="$autotoolsFiles"
     ;;
   "stable" )
     repoDir='.svn'


### PR DESCRIPTION
The important commit is cf526cd, Nov. 29th. It checks that the project actually uses libtool before attempting to apply the patch. All the rest seem to be git synchronising the commit history. Looks like all the substance was pulled in with commits to the coin-or-tools repo Aug. 2nd. The accumulated changes look correct --- substantial in run_autotools, plus the odd change in formatting.