### PR TITLE
Changes to facilitate subdirectory configure and adaptation of foreign configuration files.

### DIFF
--- a/coin.m4
+++ b/coin.m4
@@ -89,8 +89,8 @@ AC_DEFUN([AC_COIN_PROJECTVERSION],
 
 # This macro is invoked by any PROG_compiler macro to establish the
 # --enable-msvc option.
-# If unset and Windows, look for some known C compilers and set
-# enable_msvc if (i)cl is picked up (or has been set via CC by user)
+# If unset but we have a Windows environment, look for some known C compilers
+# and set enable_msvc if (i)cl is picked up (or has been set via CC by user)
 
 AC_DEFUN([AC_COIN_ENABLE_MSVC],
 [
@@ -324,7 +324,7 @@ AC_DEFUN([AC_COIN_PROG_LIBTOOL],
 #    and explicitly dll-exporting them, leading to warnings about duplicates
 #    regarding those that are properly marked for dll-export in the source.
 #
-# Patch libtool also to circumbent some issues when using MinGW (Msys+GCC).
+# Patch libtool also to circumvent some issues when using MinGW (Msys+GCC).
 # 1. Relax check which libraries can be used when linking a DLL.
 #    libtool's func_mode_link() would reject linking MinGW system libraries,
 #    e.g., -lmingw32, when building a DLL, because it does not find this
@@ -396,22 +396,29 @@ AC_DEFUN_ONCE([AC_COIN_PROG_CC],
   AC_BEFORE([$0],[LT_INIT])
 
   # If enable-msvc, then test for Intel (on Windows) and MS C compiler
-  # explicitly and add compile-wrapper before AC_PROG_CC, because
-  # the compile-wrapper work around issues when having the wrong link.exe
-  # in the PATH first, which would upset tests in AC_PROG_CC.
-  # Further, if CC unset and not set by user, then stop with error.
+  # explicitly and add the compile wrapper before AC_PROG_CC. The compile
+  # wrapper works around issues related to finding MS link.exe. (Unix link.exe
+  # occurs first in PATH, which causes compile and link checks to fail.) For
+  # the same reason, set LD to use the compile wrapper. If CC remains unset
+  # (neither icl or cl was found, and CC was not set by the user), stop with
+  # an error.
+
   if test $enable_msvc = yes ; then
     AC_CHECK_PROGS(CC, [icl cl])
     if test -n "$CC" ; then
       CC="$am_aux_dir/compile $CC"
+      ac_cv_prog_CC="$CC"
+      LD="$CC"
     else
       AC_MSG_ERROR([Neither MS nor Intel C compiler found in PATH and CC is unset.])
     fi
   fi
 
-  # look for some C compiler and check whether it works
-  # if user has set CC or we found icl/cl above, this shouldn't overwrite CC
-  # other than CXX of F77, this macro also takes care of adding the compile-wrapper
+  # Look for some C compiler and check that it works. If the user has set CC
+  # or we found icl/cl above, this shouldn't overwrite CC. Unlike the macros
+  # that establish C++ or Fortran compilers, PROG_CC also takes care of adding
+  # the compile wrapper if needed.
+
   AC_PROG_CC([gcc clang cc icc icl cl cc xlc xlc_r pgcc])
 ])
 
@@ -424,25 +431,32 @@ AC_DEFUN_ONCE([AC_COIN_PROG_CXX],
   AC_REQUIRE([AC_COIN_ENABLE_MSVC])
   AC_REQUIRE([AC_COIN_PROG_CC])
 
-  # If enable-msvc, then test for Intel (on Windows) and MS C++ compiler
-  # explicitly and add compile-wrapper before AC_PROG_CXX, because
-  # the compile-wrapper work around issues when having the wrong link.exe
-  # in the PATH first, which would upset tests in AC_PROG_CXX.
-  # Further, if CXX unset and not set by user, then stop with error.
+  # If enable-msvc, then test for Intel (on Windows) and MS C compiler
+  # explicitly and add the compile wrapper before AC_PROG_CXX. The compile
+  # wrapper works around issues related to finding MS link.exe. (Unix link.exe
+  # occurs first in PATH, which causes compile and link checks to fail.) For
+  # the same reason, set LD to use the compile wrapper. If CC remains unset
+  # (neither icl or cl was found, and CC was not set by the user), stop with
+  # an error.
+
   if test $enable_msvc = yes ; then
     AC_CHECK_PROGS(CXX, [icl cl])
     if test -n "$CXX" ; then
       CXX="$am_aux_dir/compile $CXX"
+      ac_cv_prog_CXX="$CXX"
+      LD="$CXX"
     else
       AC_MSG_ERROR([Neither MS nor Intel C++ compiler found in PATH and CXX is unset.])
     fi
   fi
 
-  # look for some C++ compiler and check whether it works
-  # if user has set CXX or we found icl/cl above, this shouldn't overwrite CXX
+  # Look for some C++ compiler and check that it works. If the user has set
+  # CXX or we found icl/cl above, this shouldn't overwrite CXX.
+
   AC_PROG_CXX([g++ clang++ c++ pgCC icpc gpp cxx cc++ icl cl FCC KCC RCC xlC_r aCC CC])
 
-  # If the compiler does not support -c -o, then wrap the compile script around it.
+  # If the compiler does not support -c -o, wrap it with the compile script.
+
   AC_PROG_CXX_C_O
   if test $ac_cv_prog_cxx_c_o = no ; then
     CXX="$am_aux_dir/compile $CXX"

--- a/coin_fortran.m4
+++ b/coin_fortran.m4
@@ -64,18 +64,21 @@ AC_DEFUN_ONCE([AC_COIN_PROG_F77],
     unset F77
   else
     # If enable-msvc, then test for Intel Fortran compiler for Windows
-    # explicitly and add compile-wrapper before AC_PROG_F77, because
-    # the compile-wrapper work around issues when having the wrong link.exe
-    # in the PATH first, which could upset tests in AC_PROG_F77.
+    # explicitly and add the compile wrapper before AC_PROG_F77. The compile
+    # wrapper works around issues related to finding MS link.exe. (Unix
+    # link.exe occurs first in PATH, which causes compile and link checks to
+    # fail.) For the same reason, set LD to use the compile wrapper.
     if test $enable_msvc = yes ; then
       AC_CHECK_PROGS(F77, [ifort])
       if test -n "$F77" ; then
         F77="$am_aux_dir/compile $F77"
+	ac_cv_prog_F77="$F77"
+        LD="$F77"
       fi
     fi
 
-    # if not msvc-enabled, then look for some Fortran compiler and check whether it works
-    # if F77 is set, then this only checks whether it works
+    # If not msvc-enabled, then look for some Fortran compiler and check
+    # whether it works. If F77 is set, this simply checks whether it works.
     if test $enable_msvc = no || test -n "$F77" ; then
       AC_PROG_F77([gfortran ifort g95 fort77 f77 f95 f90 g77 pgf90 pgf77 ifc frt af77 xlf_r fl32])
     fi

--- a/run_autotools
+++ b/run_autotools
@@ -115,12 +115,15 @@ cleanupOnErrorExit ()
 
 printHelp () {
   cat <<EOF
-usage: run_autotools [-h] [-[n]r] [-ni] [ directory directory ... ]
+usage: run_autotools [-h] [-[n]r] [-ni] [-f] [ directory directory ... ]
 
   -h  | --help           print help message and exit
   -r  | --recursion      do recursive search for configure.ac files
   -nr | --no-recursion   do not do recursive search for configure.ac files
-  -ni | --dependent      do not install scripts necessary for an independent unit
+  -ni | --dependent      do not install scripts necessary for an independent
+  			 unit
+  -f  | --foreign        process foreign configuration files (configure.ac
+                         does not contain COIN configuration macros).
   -d  | --dryrun         exit immediately after determining the list of
                          directories to be processed
 
@@ -145,6 +148,11 @@ usage: run_autotools [-h] [-[n]r] [-ni] [ directory directory ... ]
   configure.ac files. Hence the default of no recursion and install autotools
   scripts.  The -r option is useful if you have multiple COIN projects in
   sibling directories and want to do a batch run of autotools on all of them.
+
+  The -f (--foreign) option causes run_autotools to process any configure.ac,
+  even if it contains no COIN macros. Occasionally useful for adapting
+  ThirdParty native configuration for COIN. Be sure you know what you're
+  doing.
 
   The environment variable AUTOTOOLS_DIR can be used to point to an alternate
   installation of the autotools (current location $AUTOTOOLS_DIR)
@@ -332,6 +340,9 @@ while [[ $# -gt 0 ]] ; do
     -d | --dryrun )
       dryRun=1
       ;;
+    -f | --foreign )
+      doForeign=1
+      ;;
     -* ) echo "$0: unrecognised command line switch '"$1"'."
       printHelp=1
       ;;
@@ -446,7 +457,8 @@ echo "candDirs (${#candDirs[@]}): ${candDirs[*]}"
 
 for dir in ${candDirs[@]} ; do
   if [[ -r $dir/configure.ac ]] ; then
-    if grep AC_COIN_ $dir/configure.ac &>/dev/null ; then
+    if grep AC_COIN_ $dir/configure.ac &>/dev/null || \
+       test $doForeign -eq 1 ; then
       dirs+=($dir)
     else
       echo "  Skipping foreign configure.ac in '$dir'."


### PR DESCRIPTION
The significant changes in coin.m4 are setting a cache variable for CC, CXX, F77, and also setting LD.  In run_autotools, I added an option to force it to process a foreign configuration files.